### PR TITLE
Sets up authentication via SAML

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ flask = "*"
 requests = "*"
 "boto3" = "*"
 gunicorn = "*"
+"python3-saml" = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1e98bc8ae535bf26112577fd48b89aff68f1d14b893a351156d4ebe4982cf0ca"
+            "sha256": "767f24e2d634a26818022cef1db78507b6dad1cdd1d4cd9c025df1a3ddbbdbd4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,25 +18,25 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:40872be3cab0e1078e97aa0cfa8d836841d4e0acf40f5a4e59c6c33eacaea321",
-                "sha256:cc189072a38250d79f61660e83c0af899ff45e9de5f05b0a54f3a8a27b87d153"
+                "sha256:1c616cdb943bf0479f7556695a929be14388ce0e2391360b5dc351b815f45906",
+                "sha256:308a1029a1c6a79e28bfba54315a83c875c5ac970b7dbf2d8242faaac16836b7"
             ],
             "index": "pypi",
-            "version": "==1.9.51"
+            "version": "==1.9.58"
         },
         "botocore": {
             "hashes": [
-                "sha256:4209c43f6913470371bda03aea01c933247dc9592421eb1abf1fb9f594f60a35",
-                "sha256:ddbd84e0c8f9bd29f9f67e10089df87089d0f10a8a45e156c7d2def7707d0113"
+                "sha256:3ecfc578a9268aab38149c29bcc69c74a6e72b38db61f55226acf2b95296ab35",
+                "sha256:564e2332a2862997ed700dd4ae6824399b5132cc084cc60f51eb692d599e0869"
             ],
-            "version": "==1.12.51"
+            "version": "==1.12.58"
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [
@@ -51,6 +51,13 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4",
+                "sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20"
+            ],
+            "version": "==0.5.0"
         },
         "docutils": {
             "hashes": [
@@ -83,6 +90,13 @@
             ],
             "version": "==2.7"
         },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -103,6 +117,41 @@
                 "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
             ],
             "version": "==0.9.3"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:02bc220d61f46e9b9d5a53c361ef95e9f5e1d27171cd461dddb17677ae2289a5",
+                "sha256:22f253b542a342755f6cfc047fe4d3a296515cf9b542bc6e261af45a80b8caf6",
+                "sha256:2f31145c7ff665b330919bfa44aacd3a0211a76ca7e7b441039d2a0b0451e415",
+                "sha256:36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f",
+                "sha256:438a1b0203545521f6616132bfe0f4bca86f8a401364008b30e2b26ec408ce85",
+                "sha256:4815892904c336bbaf73dafd54f45f69f4021c22b5bad7332176bbf4fb830568",
+                "sha256:5be031b0f15ad63910d8e5038b489d95a79929513b3634ad4babf77100602588",
+                "sha256:5c93ae37c3c588e829b037fdfbd64a6e40c901d3f93f7beed6d724c44829a3ad",
+                "sha256:60842230678674cdac4a1cf0f707ef12d75b9a4fc4a565add4f710b5fcf185d5",
+                "sha256:62939a8bb6758d1bf923aa1c13f0bcfa9bf5b2fc0f5fa917a6e25db5fe0cfa4e",
+                "sha256:75830c06a62fe7b8fe3bbb5f269f0b308f19f3949ac81cfd40062f47c1455faf",
+                "sha256:81992565b74332c7c1aff6a913a3e906771aa81c9d0c68c68113cffcae45bc53",
+                "sha256:8c892fb0ee52c594d9a7751c7d7356056a9682674b92cc1c4dc968ff0f30c52f",
+                "sha256:9d862e3cf4fc1f2837dedce9c42269c8c76d027e49820a548ac89fdcee1e361f",
+                "sha256:a623965c086a6e91bb703d4da62dabe59fe88888e82c4117d544e11fd74835d6",
+                "sha256:a7783ab7f6a508b0510490cef9f857b763d796ba7476d9703f89722928d1e113",
+                "sha256:aab09fbe8abfa3b9ce62aaf45aca2d28726b1b9ee44871dbe644050a2fff4940",
+                "sha256:abf181934ac3ef193832fb973fd7f6149b5c531903c2ec0f1220941d73eee601",
+                "sha256:ae07fa0c115733fce1e9da96a3ac3fa24801742ca17e917e0c79d63a01eeb843",
+                "sha256:b9c78242219f674ab645ec571c9a95d70f381319a23911941cd2358a8e0521cf",
+                "sha256:bccb267678b870d9782c3b44d0cefe3ba0e329f9af8c946d32bf3778e7a4f271",
+                "sha256:c4df4d27f4c93b2cef74579f00b1d3a31a929c7d8023f870c4b476f03a274db4",
+                "sha256:caf0e50b546bb60dfa99bb18dfa6748458a83131ecdceaf5c071d74907e7e78a",
+                "sha256:d3266bd3ac59ac4edcd5fa75165dee80b94a3e5c91049df5f7c057ccf097551c",
+                "sha256:db0d213987bcd4e6d41710fb4532b22315b0d8fb439ff901782234456556aed1",
+                "sha256:dbbd5cf7690a40a9f0a9325ab480d0fccf46d16b378eefc08e195d84299bfae1",
+                "sha256:e16e07a0ec3a75b5ee61f2b1003c35696738f937dc8148fbda9fe2147ccb6e61",
+                "sha256:e175a006725c7faadbe69e791877d09936c0ef2cf49d01b60a6c1efcb0e8be6f",
+                "sha256:edd9c13a97f6550f9da2236126bb51c092b3b1ce6187f2bd966533ad794bbb5e",
+                "sha256:fa39ea60d527fbdd94215b5e5552f1c6a912624521093f1384a491a8ad89ad8b"
+            ],
+            "version": "==4.2.5"
         },
         "markupsafe": {
             "hashes": [
@@ -137,6 +186,13 @@
             ],
             "version": "==1.1.0"
         },
+        "pkgconfig": {
+            "hashes": [
+                "sha256:048c3b457da7b6f686b647ab10bf09e2250e4c50acfe6f215398a8b5e6fcdb52",
+                "sha256:3eb03a6345d4916489d3433f60e6d044a21f50e1d86fb611a52fd28061582065"
+            ],
+            "version": "==1.4.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
@@ -144,6 +200,15 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
+        },
+        "python3-saml": {
+            "hashes": [
+                "sha256:84df58c4775a354ecd2e51c44c86f033541a9396079839af464dbdd596484d2e",
+                "sha256:99c52198e8893adc56d7af55c0d095cd45710c1479b92026dda0f902c4aa633b",
+                "sha256:c8235cac3e64641bb94aa1dd989028228a582428a66a126531bf525f6065d964"
+            ],
+            "index": "pypi",
+            "version": "==1.4.1"
         },
         "requests": {
             "hashes": [
@@ -181,6 +246,12 @@
                 "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
             ],
             "version": "==0.14.1"
+        },
+        "xmlsec": {
+            "hashes": [
+                "sha256:e573c0172174973223d874ffd158ecd4e0faa761015474385289a6468dd29ed6"
+            ],
+            "version": "==1.3.3"
         }
     },
     "develop": {

--- a/ebooks/__init__.py
+++ b/ebooks/__init__.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 
 from flask import Flask
 
+import os
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 import ebooks.queries
 import ebooks.views

--- a/ebooks/__init__.py
+++ b/ebooks/__init__.py
@@ -5,6 +5,7 @@ from flask import Flask
 import os
 
 app = Flask(__name__)
+app.config['ALEPH_API_KEY'] = os.getenv('ALEPH_API_KEY')
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
 
 import ebooks.queries

--- a/ebooks/views.py
+++ b/ebooks/views.py
@@ -1,20 +1,47 @@
-from ebooks import app
-from flask import abort, render_template, send_file
-from ebooks.queries import get_file, get_filenames, get_metadata, get_volumes
+from flask import (abort, redirect, render_template,
+                   request, send_file, url_for)
+from flask_login import (current_user, login_required,
+                         login_user, LoginManager, logout_user, UserMixin)
+
+from werkzeug.urls import url_parse
+
+import os
 import requests
+
+from ebooks import app
+from ebooks.queries import get_file, get_filenames, get_metadata, get_volumes
+
+ALEPH_API_KEY = os.getenv('ALEPH_API_KEY')
+login = LoginManager(app)
+login.login_view = 'login'
+
+
+# Define the login route function here
+@app.route("/login")
+def login():
+    next_page = request.args.get('next')
+    if not next_page or url_parse(next_page).netloc != '':
+        next_page = url_for('index')
+    if current_user.is_authenticated:
+        return redirect(next_page)
+    # Log in user here and redirect to next_page
+    # Call authenticate function
+    # Create user variable that is instance of User class, with results of
+    #       authenticate function?
+    # Call login_user(user)
+    return("Login process to be implemented")
 
 
 @app.route("/")
 @app.route("/<item>")
+# @login_required
 def index(item="002341336"):
     files = get_filenames(item)
 
     metadata = {}
     try:
-        # record = requests.get("http://library.mit.edu/rest-dlf/record/mit01" +
-        #                       item + "?view=full")
-        record = requests.get("http://walter.mit.edu/rest-dlf/record/mit01" +
-                              item + "?view=full")
+        record = requests.get("https://library.mit.edu/rest-dlf/record/mit01" +
+                              item + "?view=full&key=" + ALEPH_API_KEY)
         marc_xml = record.content
         metadata = get_metadata(marc_xml)
     except:
@@ -34,6 +61,7 @@ def index(item="002341336"):
 
 
 @app.route('/docs/<filename>')
+@login_required
 def file(filename):
     if '..' in filename or filename.startswith('/'):
         abort(404)

--- a/ebooks/views.py
+++ b/ebooks/views.py
@@ -1,51 +1,148 @@
-from flask import (abort, redirect, render_template,
-                   request, send_file, url_for)
-from flask_login import (current_user, login_required,
-                         login_user, LoginManager, logout_user, UserMixin)
-
-from werkzeug.urls import url_parse
-
-import os
-import requests
-
 from ebooks import app
 from ebooks.queries import get_file, get_filenames, get_metadata, get_volumes
 
-ALEPH_API_KEY = os.getenv('ALEPH_API_KEY')
-login = LoginManager(app)
-login.login_view = 'login'
+from flask import (abort, make_response, redirect, render_template, request,
+                   session, send_file, url_for)
+
+from functools import wraps
+from urllib.parse import urljoin, urlparse
+
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+
+import json
+import os
+import requests
 
 
-# Define the login route function here
-@app.route("/login")
-def login():
+json_settings = {}
+with open("saml/settings.json", 'r') as json_file:
+    json_settings = json.load(json_file)
+    json_settings['debug'] = app.config['DEBUG']
+    json_settings['sp']['entityId'] = os.getenv('SP_ENTITY_ID')
+    json_settings['sp']['assertionConsumerService']['url'] = \
+        os.getenv('SP_ACS_URL')
+    json_settings['sp']['singleLogoutService']['url'] = os.getenv('SP_SLS_URL')
+    json_settings['sp']['x509cert'] = os.getenv('SP_CERT')
+    json_settings['sp']['privateKey'] = os.getenv('SP_KEY')
+    json_settings['idp']['entityId'] = os.getenv('IDP_ENTITY_ID')
+    json_settings['idp']['singleSignOnService']['url'] = \
+        os.getenv('IDP_SSO_URL')
+    json_settings['idp']['singleLogoutService']['url'] = \
+        os.getenv('IDP_SLS_URL')
+    json_settings['idp']['x509cert'] = os.getenv('IDP_CERT')
+
+
+def init_saml_auth(req):
+    auth = OneLogin_Saml2_Auth(req, json_settings)
+    return auth
+
+
+def is_safe_url(target):
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+    return test_url.scheme in ('http', 'https') and \
+        ref_url.netloc == test_url.netloc
+
+
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'samlSessionIndex' not in session:
+            return redirect(url_for('shibboleth', sso=True, next=request.url))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+def prepare_flask_request(request):
+    url_data = urlparse(request.url)
+    return {
+        'https': 'on' if request.scheme == 'https' else 'off',
+        'http_host': request.host,
+        'server_port': url_data.port,
+        'script_name': request.path,
+        'get_data': request.args.copy(),
+        'post_data': request.form.copy()
+    }
+
+
+@app.route('/shibboleth/', methods=['GET', 'POST'])
+def shibboleth():
+    req = prepare_flask_request(request)
+    auth = init_saml_auth(req)
+    errors = []
     next_page = request.args.get('next')
-    if not next_page or url_parse(next_page).netloc != '':
-        next_page = url_for('index')
-    if current_user.is_authenticated:
-        return redirect(next_page)
-    # Log in user here and redirect to next_page
-    # Call authenticate function
-    # Create user variable that is instance of User class, with results of
-    #       authenticate function?
-    # Call login_user(user)
-    return("Login process to be implemented")
+    if not next_page or is_safe_url(next_page) is False:
+        next_page = ''
+
+    if 'sso' in request.args:
+        return redirect(auth.login(return_to=next_page))
+
+    elif 'slo' in request.args:
+        name_id = None
+        session_index = None
+        if 'samlNameId' in session:
+            name_id = session['samlNameId']
+        if 'samlSessionIndex' in session:
+            session_index = session['samlSessionIndex']
+        return redirect(auth.logout(name_id=name_id,
+                                    session_index=session_index))
+
+    elif 'acs' in request.args:
+        auth.process_response()
+        errors = auth.get_errors()
+        if not auth.is_authenticated():
+            # TODO: return something helpful to the user
+            pass
+        if len(errors) == 0:
+            session['samlUserdata'] = auth.get_attributes()
+            session['samlNameId'] = auth.get_nameid()
+            session['samlSessionIndex'] = auth.get_session_index()
+            return redirect(request.form['RelayState'])
+        else:
+            print(errors)
+
+    elif 'sls' in request.args:
+        def dscb(): session.clear()
+        url = auth.process_slo(delete_session_cb=dscb)
+        errors = auth.get_errors()
+        if len(errors) == 0:
+            if url is not None:
+                return redirect(url)
+            else:
+                # TODO: Do something useful here?
+                return redirect('')
 
 
-@app.route("/")
-@app.route("/<item>")
-# @login_required
-def index(item="002341336"):
-    files = get_filenames(item)
+@app.route('/shibboleth/metadata/')
+def metadata():
+    req = prepare_flask_request(request)
+    auth = init_saml_auth(req)
+    settings = auth.get_settings()
+    metadata = settings.get_sp_metadata()
+    errors = settings.validate_metadata(metadata)
 
-    metadata = {}
+    if len(errors) == 0:
+        resp = make_response(metadata, 200)
+        resp.headers['Content-Type'] = 'text/xml'
+    else:
+        resp = make_response(', '.join(errors), 500)
+    return resp
+
+
+@app.route("/item/")
+@app.route("/item/<item>")
+@login_required
+def item(item="002341336"):
     try:
+        files = get_filenames(item)
+        metadata = {}
         record = requests.get("https://library.mit.edu/rest-dlf/record/mit01" +
-                              item + "?view=full&key=" + ALEPH_API_KEY)
+                              item + "?view=full&key=" +
+                              app.config['ALEPH_API_KEY'])
         marc_xml = record.content
         metadata = get_metadata(marc_xml)
-    except:
-        metadata['Error'] = 'Item not found.'
+    except AttributeError:
+            metadata['Error'] = 'Item not found.'
 
     fields = ['Title', 'Author', 'Edition', 'Publication', 'Series', 'ISBN',
               'ISSN', 'Original Version', 'Error']

--- a/runserver.py
+++ b/runserver.py
@@ -1,0 +1,2 @@
+from ebooks import app
+app.run(debug=True)

--- a/saml/settings.json
+++ b/saml/settings.json
@@ -1,0 +1,30 @@
+{
+    "strict": true,
+    "debug": "",
+    "sp": {
+        "entityId": "",
+        "assertionConsumerService": {
+            "url": "",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        },
+        "singleLogoutService": {
+            "url": "",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+        "x509cert": "",
+        "privateKey": ""
+    },
+    "idp": {
+        "entityId": "",
+        "singleSignOnService": {
+            "url": "",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        },
+        "singleLogoutService": {
+            "url": "",
+            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        },
+        "x509cert": ""
+    }
+}


### PR DESCRIPTION
Adds routing and config to authenticate users via SAML (to work with MIT Touchstone auth), and protects views.

Todo: add tests (working on this, but wanted to get initial SAML routes up so I can start connecting it to Touchstone), update documentation.