### PR TITLE
Update saml config for MIT IDP reqs

### DIFF
--- a/saml/settings.json
+++ b/saml/settings.json
@@ -7,11 +7,6 @@
             "url": "",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
         },
-        "singleLogoutService": {
-            "url": "",
-            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
         "x509cert": "",
         "privateKey": ""
     },
@@ -20,10 +15,6 @@
         "singleSignOnService": {
             "url": "",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-        },
-        "singleLogoutService": {
-            "url": "",
-            "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
         "x509cert": ""
     }


### PR DESCRIPTION
Removes single logout service, which MIT Touchstone does not support, changes endpoint name from "shibboleth" to "saml" by IS&T request