### PR TITLE
Update dependencies with latest version of Pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ gunicorn = "*"
 python3-saml = "*"
 moto = "==1.3.4"
 flask-sslify = "*"
-sentry-sdk = {extras = ["flask"], version = "*"}
+sentry-sdk = {extras = ["flask"],version = "*"}
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,7 +34,6 @@
             "hashes": [
                 "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
             ],
-            "markers": "extra == 'flask'",
             "version": "==1.4"
         },
         "boto": {
@@ -480,11 +479,11 @@
                 "flask"
             ],
             "hashes": [
-                "sha256:3175701058b6196db306125d09d96c0651618c723bac64a210dd47d658eb7751",
-                "sha256:55e246656a0a718cdece5a961129a9219f69c8bd7aa8f6888c1ec142930fb958"
+                "sha256:635f2c9dde9995150435a4f6ba06a944ba94e9754ad7594b42c2fcb001a44dfd",
+                "sha256:c1ff8034b819b46b38d110f5d7d613450dd047469924be0fdfb77c67c24f7df4"
             ],
             "index": "pypi",
-            "version": "==0.6.3"
+            "version": "==0.6.4"
         },
         "six": {
             "hashes": [
@@ -575,7 +574,6 @@
             "hashes": [
                 "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
             ],
-            "markers": "extra == 'flask'",
             "version": "==1.4"
         },
         "boto": {


### PR DESCRIPTION
There was a bug in Pipenv that was causing sentry-sdk's blinker dependency to be ignored due to incorrect handling of extras. Latest Pipenv release fixed it, just updating.