### PR TITLE
Update to use Alma API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ running in development mode with `FLASK_ENV=development` in your `.env`.
 
 - The application is currently deployed on Heroku and auto-deploys to staging from Github master.
 - Environment variables needed for fully-functional deployment include:
-  - `ALEPH_API_KEY`: API key for the Barton API
-  - `ALEPH_API_URL`: Base URL for the Barton API
+  - `ALMA_API_KEY`: API key for the Alma API
+  - `ALMA_API_URL`: Base URL for the Alma bib record API
   - `AWS_ACCESS_KEY_ID`: Access key for AWS S3 bucket access
   - `AWS_BUCKET_NAME`: Name of S3 bucket
   - `AWS_REGION_NAME`
@@ -51,8 +51,8 @@ running in development mode with `FLASK_ENV=development` in your `.env`.
 ## Assumptions, of which there are several
 
 - All items presented in the application require users to be MIT authenticated for access. Authentication is done via touchstone on any attempt to access item landing pages. This application is configured as a SAML SP with MIT's Touchstone service.
-- All items presented in the application must be catalogued in Barton. Each item's metadata and file(s) are retrieved using its Barton bibliographic record number.
-- Discovery is assumed to take place in Barton, and access is provided via a link to each item's URL, included in the Barton record for the item. Item URLs follow the format http://lib-ebooks.mit.edu/item/[Barton-record-number].
+- All items presented in the application must be catalogued in Alma. Each item's metadata and file(s) are retrieved using its Alma MMS ID.
+- Discovery is assumed to take place in Primo, and access is provided via a link to each item's URL, included in the Alma/Primo record for the item. Item URLs follow the format http://lib-ebooks.mit.edu/item/<AlmaMMSID>.
 - All ebook files delivered by the application are stored in Amazon S3. Instructions for uploading files to our S3 bucket are documented in Cataloging.
 
 ## Serials

--- a/ebooks/config.py
+++ b/ebooks/config.py
@@ -6,8 +6,9 @@ class Config():
     ENV = os.getenv('FLASK_ENV', default='production')
     SECRET_KEY = os.getenv('SECRET_KEY')
 
-    ALEPH_API_KEY = os.getenv('ALEPH_API_KEY')
-    ALEPH_API_URL = os.getenv('ALEPH_API_URL')
+    ALMA_API_KEY = os.getenv('ALMA_API_KEY')
+    ALMA_API_URL = os.getenv('ALMA_API_URL')
+
     AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
     AWS_BUCKET_NAME = os.getenv('AWS_BUCKET_NAME')
     AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
@@ -25,8 +26,9 @@ class TestingConfig(Config):
     SECRET_KEY = 'testing'
     PREFERRED_URL_SCHEME = 'https'
 
-    ALEPH_API_KEY = ''
-    ALEPH_API_URL = "https://mock.com/"
+    ALMA_API_KEY = ''
+    ALMA_API_URL = "https://mock.com/"
+
     AWS_ACCESS_KEY_ID = 'testing'
     AWS_BUCKET_NAME = 'samples'
     AWS_SECRET_ACCESS_KEY = 'testing'

--- a/ebooks/item.py
+++ b/ebooks/item.py
@@ -21,9 +21,9 @@ def item(item="None"):
     bucket = current_app.config['AWS_BUCKET_NAME']
 
     try:
-        base_aleph_url = current_app.config['ALEPH_API_URL']
-        url = (base_aleph_url + item + "?view=full&key=" +
-               current_app.config['ALEPH_API_KEY'])
+        base_alma_url = current_app.config['ALMA_API_URL']
+        url = (base_alma_url + item + "?apikey=" +
+               current_app.config['ALMA_API_KEY'])
         record = requests.get(url)
         marc_xml = record.content
         metadata = get_metadata(marc_xml)

--- a/ebooks/templates/landing.html
+++ b/ebooks/templates/landing.html
@@ -128,7 +128,7 @@
               <div class="bit">
                 <h3 class="title">Related</h3>
                 <ul>
-                  <li><a href="http://library.mit.edu/item/{{ file_id }}">View this item in the catalog</a></li>
+                  <li><a href="https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=alma{{ file_id }}">View this item in the catalog</a></li>
                 </ul>
               </div>
             {% endblock %}
@@ -154,17 +154,17 @@
                     <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
                     <span class="sr">Twitter</span>
                   </a><!-- End Twitter -->
-                  
+
                   <a href="https://www.facebook.com/mitlib" title="Facebook">
                     <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
                     <span class="sr">Facebook</span>
                   </a><!-- End Facebook -->
-                  
+
                   <a href="https://instagram.com/mitlibraries/" title="Instagram">
                     <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
                     <span class="sr">Instagram</span>
                   </a><!-- End Instagram -->
-                  
+
                   <a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
                     <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
                     <span class="sr">YouTube</span>

--- a/ebooks/templates/serial.html
+++ b/ebooks/templates/serial.html
@@ -110,7 +110,7 @@
               <div class="bit">
                 <h3 class="title">Related</h3>
                 <ul>
-                  <li><a href="http://library.mit.edu/item/{{ file_id }}">View this item in the catalog</a></li>
+                  <li><a href="https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=alma{{ file_id }}">View this item in the catalog</a></li>
                 </ul>
               </div>
             {% endblock %}
@@ -136,17 +136,17 @@
                     <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
                     <span class="sr">Twitter</span>
                   </a><!-- End Twitter -->
-                  
+
                   <a href="https://www.facebook.com/mitlib" title="Facebook">
                     <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
                     <span class="sr">Facebook</span>
                   </a><!-- End Facebook -->
-                  
+
                   <a href="https://instagram.com/mitlibraries/" title="Instagram">
                     <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
                     <span class="sr">Instagram</span>
                   </a><!-- End Instagram -->
-                  
+
                   <a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
                     <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
                     <span class="sr">YouTube</span>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,13 +67,13 @@ def serial():
 
 
 @pytest.fixture
-def aleph(record, serial):
+def alma(record, serial):
     with requests_mock.Mocker() as m:
-        m.get('https://mock.com/sample?view=full&key=',
+        m.get('https://mock.com/sample?apikey=',
               status_code=200, content=record.encode())
-        m.get('https://mock.com/serial?view=full&key=',
+        m.get('https://mock.com/serial?apikey=',
               status_code=200, content=serial.encode())
-        m.get('https://mock.com/fake_item?view=full&key=',
+        m.get('https://mock.com/fake_item?apikey=',
               status_code=200,
               content=('<?xmlversion = "1.0" encoding = ''"UTF-8"?>'
                        '<get-record><reply-text>Record does not exist'

--- a/tests/fixtures/sample.xml
+++ b/tests/fixtures/sample.xml
@@ -1,162 +1,178 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<get-record>
-    <reply-text>ok</reply-text>
-    <reply-code>0000</reply-code>
-    <record>
-        <info type="Items" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/items"/>
-        <info type="Holdings" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/holdings"/>
-        <info type="Filters" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/filters"/>
-        <leader>     nam  2200385Ii 4500</leader>
-        <controlfield tag="005">20150806072509.0</controlfield>
-        <controlfield tag="006">m     o  d</controlfield>
-        <controlfield tag="007">cr |||</controlfield>
-        <controlfield tag="008">150805r20151972maua    ob   f000 0 eng d</controlfield>
-        <datafield tag="035" ind1=" " ind2=" ">
-            <subfield code="a">(OCoLC)915832153</subfield>
-        </datafield>
-        <datafield tag="020" ind1=" " ind2=" ">
-            <subfield code="a">ISBN</subfield>
-        </datafield>
-        <datafield tag="022" ind1=" " ind2=" ">
-            <subfield code="a">ISSN</subfield>
-        </datafield>
-        <datafield tag="040" ind1=" " ind2=" ">
-            <subfield code="a">MYG</subfield>
-            <subfield code="b">eng</subfield>
-            <subfield code="e">rda</subfield>
-            <subfield code="c">MYG</subfield>
-            <subfield code="d">MYG</subfield>
-        </datafield>
-        <datafield tag="050" ind1="1" ind2="4">
-            <subfield code="a">TA710</subfield>
-            <subfield code="b">.F56 1972a</subfield>
-        </datafield>
-        <datafield tag="100" ind1="1" ind2=" ">
-            <subfield code="a">Florin, V. A.</subfield>
-            <subfield code="q">(Viktor Anatolʹevich),</subfield>
-            <subfield code="e">author.</subfield>
-        </datafield>
-        <datafield tag="240" ind1="1" ind2="0">
-            <subfield code="a">Osnovy mekhaniki gruntov.</subfield>
-            <subfield code="l">English</subfield>
-        </datafield>
-        <datafield tag="245" ind1="1" ind2="0">
-            <subfield code="a">Title/</subfield>
-            <subfield code="b">Subtitle/</subfield>
-            <subfield code="n">Volume 1,</subfield>
-            <subfield code="p">General relationships and state of stress caused by foundation loads / by V.A. Florin ; translation edited by Robert L. Schiffman.</subfield>
-        </datafield>
-        <datafield tag="246" ind1="3" ind2=" ">
-            <subfield code="a">General relationships and state of stress caused by foundation loads</subfield>
-        </datafield>
-        <datafield tag="250" ind1="3" ind2=" ">
-            <subfield code="a">Edition 1</subfield>
-        </datafield>
-        <datafield tag="264" ind1=" " ind2="1">
-            <subfield code="a">[Cambridge, Massachusetts] :</subfield>
-            <subfield code="b">[MIT Libraries Curation and Preservation Services],</subfield>
-            <subfield code="c">[2015]</subfield>
-        </datafield>
-        <datafield tag="300" ind1=" " ind2=" ">
-            <subfield code="a">1 online resource :</subfield>
-            <subfield code="b">illustrations</subfield>
-        </datafield>
-        <datafield tag="336" ind1=" " ind2=" ">
-            <subfield code="a">text</subfield>
-            <subfield code="b">txt</subfield>
-            <subfield code="2">rdacontent</subfield>
-        </datafield>
-        <datafield tag="337" ind1=" " ind2=" ">
-            <subfield code="a">computer</subfield>
-            <subfield code="b">c</subfield>
-            <subfield code="2">rdamedia</subfield>
-        </datafield>
-        <datafield tag="338" ind1=" " ind2=" ">
-            <subfield code="a">online resource</subfield>
-            <subfield code="b">cr</subfield>
-            <subfield code="2">rdacarrier</subfield>
-        </datafield>
-        <datafield tag="500" ind1=" " ind2=" ">
-            <subfield code="a">"Translated from Russian."</subfield>
-        </datafield>
-        <datafield tag="534" ind1=" " ind2=" ">
-            <subfield code="p">Digital reproduction of:</subfield>
-            <subfield code="a">Florin, V. A. (Viktor Anatolʹevich).</subfield>
-            <subfield code="t">Fundamentals of soil mechanics. Volume 1, General relationships and state of stress caused by foundation loads.</subfield>
-            <subfield code="c">Springfield, VA :</subfield>
-            <subfield code="b">National Tehcnical Information Service, 1972.</subfield>
-        </datafield>
-        <datafield tag="500" ind1=" " ind2=" ">
-            <subfield code="a">"PB-268 833-T."</subfield>
-        </datafield>
-        <datafield tag="504" ind1=" " ind2=" ">
-            <subfield code="a">Includes bibliographical references (pages R1-R11).</subfield>
-        </datafield>
-        <datafield tag="588" ind1=" " ind2=" ">
-            <subfield code="a">Title from PDF title page.</subfield>
-        </datafield>
-        <datafield tag="650" ind1=" " ind2="0">
-            <subfield code="a">Soil mechanics.</subfield>
-        </datafield>
-        <datafield tag="650" ind1=" " ind2="0">
-            <subfield code="a">Foundations.</subfield>
-        </datafield>
-        <datafield tag="700" ind1="1" ind2=" ">
-            <subfield code="a">Schiffman, Robert L.,</subfield>
-            <subfield code="e">translator,</subfield>
-            <subfield code="e">editor.</subfield>
-        </datafield>
-        <datafield tag="830" ind1="1" ind2=" ">
-            <subfield code="a">Series title</subfield>
-            <subfield code="v">Series numbering</subfield>
-        </datafield>
-        <datafield tag="856" ind1="4" ind2="0">
-            <subfield code="u">http://dome.mit.edu/handle/1721.3/148790</subfield>
-        </datafield>
-        <datafield tag="049" ind1=" " ind2=" ">
-            <subfield code="a">MYGG</subfield>
-        </datafield>
-        <datafield tag="910" ind1=" " ind2=" ">
-            <subfield code="a">ba150805</subfield>
-            <subfield code="b">new</subfield>
-            <subfield code="c">~</subfield>
-            <subfield code="e">misc</subfield>
-            <subfield code="j">a</subfield>
-            <subfield code="k">m</subfield>
-            <subfield code="l">o</subfield>
-            <subfield code="m">I</subfield>
-            <subfield code="o">rda</subfield>
-            <subfield code="p">MYG</subfield>
-            <subfield code="q">n</subfield>
-            <subfield code="r">i</subfield>
-            <subfield code="s">1</subfield>
-            <subfield code="w">~</subfield>
-            <subfield code="x">0</subfield>
-            <subfield code="y">~</subfield>
-            <subfield code="z">~</subfield>
-            <subfield code="i">ba</subfield>
-            <subfield code="d">150805</subfield>
-            <subfield code="n">n</subfield>
-        </datafield>
-        <datafield tag="949" ind1=" " ind2="1">
-            <subfield code="1">Internet Access</subfield>
-            <subfield code="a">n</subfield>
-            <subfield code="b">NET</subfield>
-            <subfield code="h">**See URL(s)</subfield>
-            <subfield code="o">8</subfield>
-            <subfield code="x">02</subfield>
-        </datafield>
-        <datafield tag="994" ind1=" " ind2=" ">
-            <subfield code="a">02</subfield>
-            <subfield code="b">MYG</subfield>
-        </datafield>
-        <controlfield tag="008">1508062u    8   4001uueng0000000</controlfield>
-        <controlfield tag="004">002341336</controlfield>
-        <datafield tag="852" ind1="8" ind2=" ">
-            <subfield code="b">NET</subfield>
-            <subfield code="z">Internet Access</subfield>
-            <subfield code="h">**See URL(s)</subfield>
-        </datafield>
-        <controlfield tag="001">002341336</controlfield>
-    </record>
-</get-record>
+<bib>
+  <mms_id>990023413360106761</mms_id>
+  <record_format>marc21</record_format>
+  <linked_record_id/>
+  <title>Fundamentals of soil mechanics.</title>
+  <author>Florin, V. A.</author>
+  <network_numbers>
+    <network_number>(OCoLC)915832153</network_number>
+    <network_number>(MCM)002341336MIT01</network_number>
+  </network_numbers>
+  <place_of_publication>[Cambridge, Massachusetts] :</place_of_publication>
+  <date_of_publication>[2015]</date_of_publication>
+  <publisher_const>[MIT Libraries Curation and Preservation Services],</publisher_const>
+  <holdings link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990023413360106761/holdings"/>
+  <created_by>import</created_by>
+  <created_date>2021-06-30Z</created_date>
+  <suppress_from_publishing>false</suppress_from_publishing>
+  <suppress_from_external_search>false</suppress_from_external_search>
+  <sync_with_oclc>BIBS</sync_with_oclc>
+  <sync_with_libraries_australia>NONE</sync_with_libraries_australia>
+  <originating_system>ILS</originating_system>
+  <originating_system_id>002341336-MIT01</originating_system_id>
+  <cataloging_level desc="Default Level">00</cataloging_level>
+  <record schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+    <leader>     cam  2200397Ii 4500</leader>
+    <controlfield tag="001">990023413360106761</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(MCM)002341336MIT01</subfield>
+    </datafield>
+    <controlfield tag="005">20160220072504.0</controlfield>
+    <controlfield tag="006">m     o  d        </controlfield>
+    <controlfield tag="007">cr |||||||||||</controlfield>
+    <controlfield tag="008">150805r20151972maua    ob   f000 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)915832153</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">MYG</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">MYG</subfield>
+      <subfield code="d">OCLCF</subfield>
+      <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="050">
+      <subfield code="a">TA710</subfield>
+      <subfield code="b">.F56 1972a</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Florin, V. A.</subfield>
+      <subfield code="q">(Viktor Anatolʹevich),</subfield>
+      <subfield code="e">author.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Osnovy mekhaniki gruntov.</subfield>
+      <subfield code="k">Tom 1.</subfield>
+      <subfield code="l">English</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Fundamentals of soil mechanics.</subfield>
+      <subfield code="n">Volume 1,</subfield>
+      <subfield code="p">General relationships and state of stress caused by foundation loads / by V.A. Florin ; translation edited by Robert L. Schiffman.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2=" " tag="246">
+      <subfield code="a">General relationships and state of stress caused by foundation loads</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">[Cambridge, Massachusetts] :</subfield>
+      <subfield code="b">[MIT Libraries Curation and Preservation Services],</subfield>
+      <subfield code="c">[2015]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 online resource :</subfield>
+      <subfield code="b">illustrations</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">computer</subfield>
+      <subfield code="b">c</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">online resource</subfield>
+      <subfield code="b">cr</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">"Translated from Russian."</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="534">
+      <subfield code="p">Digital reproduction of:</subfield>
+      <subfield code="a">Florin, V. A. (Viktor Anatolʹevich).</subfield>
+      <subfield code="t">Fundamentals of soil mechanics. Volume 1, General relationships and state of stress caused by foundation loads.</subfield>
+      <subfield code="c">Springfield, VA :</subfield>
+      <subfield code="b">National Tehcnical Information Service, 1972.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">"PB-268 833-T."</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="504">
+      <subfield code="a">Includes bibliographical references (pages R1-R11).</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="588">
+      <subfield code="a">Title from PDF title page.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Soil mechanics.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Foundations.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Schiffman, Robert L.,</subfield>
+      <subfield code="e">translator,</subfield>
+      <subfield code="e">editor.</subfield>
+    </datafield>
+    <datafield ind1="4" ind2="0" tag="856">
+      <subfield code="u">https://lib-ebooks.mit.edu/item/002341336</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="049">
+      <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">ba160219</subfield>
+      <subfield code="b">mod</subfield>
+      <subfield code="c">~</subfield>
+      <subfield code="e">recat</subfield>
+      <subfield code="j">a</subfield>
+      <subfield code="k">m</subfield>
+      <subfield code="l">o</subfield>
+      <subfield code="m">I</subfield>
+      <subfield code="o">rda</subfield>
+      <subfield code="p">MYG</subfield>
+      <subfield code="q">n</subfield>
+      <subfield code="r">i</subfield>
+      <subfield code="s">1</subfield>
+      <subfield code="w">~</subfield>
+      <subfield code="x">0</subfield>
+      <subfield code="y">~</subfield>
+      <subfield code="z">~</subfield>
+      <subfield code="i">ba</subfield>
+      <subfield code="d">160219</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="946">
+      <subfield code="m">mit-hosted</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="994">
+      <subfield code="a">C0</subfield>
+      <subfield code="b">MYG</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">ba150805</subfield>
+      <subfield code="b">new</subfield>
+      <subfield code="c">~</subfield>
+      <subfield code="e">misc</subfield>
+      <subfield code="j">a</subfield>
+      <subfield code="k">m</subfield>
+      <subfield code="l">o</subfield>
+      <subfield code="m">I</subfield>
+      <subfield code="o">rda</subfield>
+      <subfield code="p">MYG</subfield>
+      <subfield code="q">n</subfield>
+      <subfield code="r">i</subfield>
+      <subfield code="s">1</subfield>
+      <subfield code="w">~</subfield>
+      <subfield code="x">0</subfield>
+      <subfield code="y">~</subfield>
+      <subfield code="z">~</subfield>
+      <subfield code="i">ba</subfield>
+      <subfield code="d">150805</subfield>
+    </datafield>
+  </record>
+</bib>

--- a/tests/fixtures/serial.xml
+++ b/tests/fixtures/serial.xml
@@ -1,162 +1,192 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<get-record>
-    <reply-text>ok</reply-text>
-    <reply-code>0000</reply-code>
-    <record>
-        <info type="Items" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/items"/>
-        <info type="Holdings" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/holdings"/>
-        <info type="Filters" href="http://walter.mit.edu/rest-dlf/record/mit01002341336/filters"/>
-        <leader>     nas  2200385Ii 4500</leader>
-        <controlfield tag="005">20150806072509.0</controlfield>
-        <controlfield tag="006">m     o  d</controlfield>
-        <controlfield tag="007">cr |||</controlfield>
-        <controlfield tag="008">150805r20151972maua    ob   f000 0 eng d</controlfield>
-        <datafield tag="035" ind1=" " ind2=" ">
-            <subfield code="a">(OCoLC)915832153</subfield>
-        </datafield>
-        <datafield tag="020" ind1=" " ind2=" ">
-            <subfield code="a">ISBN</subfield>
-        </datafield>
-        <datafield tag="022" ind1=" " ind2=" ">
-            <subfield code="a">ISSN</subfield>
-        </datafield>
-        <datafield tag="040" ind1=" " ind2=" ">
-            <subfield code="a">MYG</subfield>
-            <subfield code="b">eng</subfield>
-            <subfield code="e">rda</subfield>
-            <subfield code="c">MYG</subfield>
-            <subfield code="d">MYG</subfield>
-        </datafield>
-        <datafield tag="050" ind1="1" ind2="4">
-            <subfield code="a">TA710</subfield>
-            <subfield code="b">.F56 1972a</subfield>
-        </datafield>
-        <datafield tag="100" ind1="1" ind2=" ">
-            <subfield code="a">Florin, V. A.</subfield>
-            <subfield code="q">(Viktor Anatolʹevich),</subfield>
-            <subfield code="e">author.</subfield>
-        </datafield>
-        <datafield tag="240" ind1="1" ind2="0">
-            <subfield code="a">Osnovy mekhaniki gruntov.</subfield>
-            <subfield code="l">English</subfield>
-        </datafield>
-        <datafield tag="245" ind1="1" ind2="0">
-            <subfield code="a">Title/</subfield>
-            <subfield code="b">Subtitle/</subfield>
-            <subfield code="n">Volume 1,</subfield>
-            <subfield code="p">General relationships and state of stress caused by foundation loads / by V.A. Florin ; translation edited by Robert L. Schiffman.</subfield>
-        </datafield>
-        <datafield tag="246" ind1="3" ind2=" ">
-            <subfield code="a">General relationships and state of stress caused by foundation loads</subfield>
-        </datafield>
-        <datafield tag="250" ind1="3" ind2=" ">
-            <subfield code="a">Edition 1</subfield>
-        </datafield>
-        <datafield tag="264" ind1=" " ind2="1">
-            <subfield code="a">[Cambridge, Massachusetts] :</subfield>
-            <subfield code="b">[MIT Libraries Curation and Preservation Services],</subfield>
-            <subfield code="c">[2015]</subfield>
-        </datafield>
-        <datafield tag="300" ind1=" " ind2=" ">
-            <subfield code="a">1 online resource :</subfield>
-            <subfield code="b">illustrations</subfield>
-        </datafield>
-        <datafield tag="336" ind1=" " ind2=" ">
-            <subfield code="a">text</subfield>
-            <subfield code="b">txt</subfield>
-            <subfield code="2">rdacontent</subfield>
-        </datafield>
-        <datafield tag="337" ind1=" " ind2=" ">
-            <subfield code="a">computer</subfield>
-            <subfield code="b">c</subfield>
-            <subfield code="2">rdamedia</subfield>
-        </datafield>
-        <datafield tag="338" ind1=" " ind2=" ">
-            <subfield code="a">online resource</subfield>
-            <subfield code="b">cr</subfield>
-            <subfield code="2">rdacarrier</subfield>
-        </datafield>
-        <datafield tag="500" ind1=" " ind2=" ">
-            <subfield code="a">"Translated from Russian."</subfield>
-        </datafield>
-        <datafield tag="534" ind1=" " ind2=" ">
-            <subfield code="p">Digital reproduction of:</subfield>
-            <subfield code="a">Florin, V. A. (Viktor Anatolʹevich).</subfield>
-            <subfield code="t">Fundamentals of soil mechanics. Volume 1, General relationships and state of stress caused by foundation loads.</subfield>
-            <subfield code="c">Springfield, VA :</subfield>
-            <subfield code="b">National Tehcnical Information Service, 1972.</subfield>
-        </datafield>
-        <datafield tag="500" ind1=" " ind2=" ">
-            <subfield code="a">"PB-268 833-T."</subfield>
-        </datafield>
-        <datafield tag="504" ind1=" " ind2=" ">
-            <subfield code="a">Includes bibliographical references (pages R1-R11).</subfield>
-        </datafield>
-        <datafield tag="588" ind1=" " ind2=" ">
-            <subfield code="a">Title from PDF title page.</subfield>
-        </datafield>
-        <datafield tag="650" ind1=" " ind2="0">
-            <subfield code="a">Soil mechanics.</subfield>
-        </datafield>
-        <datafield tag="650" ind1=" " ind2="0">
-            <subfield code="a">Foundations.</subfield>
-        </datafield>
-        <datafield tag="700" ind1="1" ind2=" ">
-            <subfield code="a">Schiffman, Robert L.,</subfield>
-            <subfield code="e">translator,</subfield>
-            <subfield code="e">editor.</subfield>
-        </datafield>
-        <datafield tag="830" ind1="1" ind2=" ">
-            <subfield code="a">Series title</subfield>
-            <subfield code="v">Series numbering</subfield>
-        </datafield>
-        <datafield tag="856" ind1="4" ind2="0">
-            <subfield code="u">http://dome.mit.edu/handle/1721.3/148790</subfield>
-        </datafield>
-        <datafield tag="049" ind1=" " ind2=" ">
-            <subfield code="a">MYGG</subfield>
-        </datafield>
-        <datafield tag="910" ind1=" " ind2=" ">
-            <subfield code="a">ba150805</subfield>
-            <subfield code="b">new</subfield>
-            <subfield code="c">~</subfield>
-            <subfield code="e">misc</subfield>
-            <subfield code="j">a</subfield>
-            <subfield code="k">m</subfield>
-            <subfield code="l">o</subfield>
-            <subfield code="m">I</subfield>
-            <subfield code="o">rda</subfield>
-            <subfield code="p">MYG</subfield>
-            <subfield code="q">n</subfield>
-            <subfield code="r">i</subfield>
-            <subfield code="s">1</subfield>
-            <subfield code="w">~</subfield>
-            <subfield code="x">0</subfield>
-            <subfield code="y">~</subfield>
-            <subfield code="z">~</subfield>
-            <subfield code="i">ba</subfield>
-            <subfield code="d">150805</subfield>
-            <subfield code="n">n</subfield>
-        </datafield>
-        <datafield tag="949" ind1=" " ind2="1">
-            <subfield code="1">Internet Access</subfield>
-            <subfield code="a">n</subfield>
-            <subfield code="b">NET</subfield>
-            <subfield code="h">**See URL(s)</subfield>
-            <subfield code="o">8</subfield>
-            <subfield code="x">02</subfield>
-        </datafield>
-        <datafield tag="994" ind1=" " ind2=" ">
-            <subfield code="a">02</subfield>
-            <subfield code="b">MYG</subfield>
-        </datafield>
-        <controlfield tag="008">1508062u    8   4001uueng0000000</controlfield>
-        <controlfield tag="004">002341336</controlfield>
-        <datafield tag="852" ind1="8" ind2=" ">
-            <subfield code="b">NET</subfield>
-            <subfield code="z">Internet Access</subfield>
-            <subfield code="h">**See URL(s)</subfield>
-        </datafield>
-        <controlfield tag="001">002341336</controlfield>
-    </record>
-</get-record>
+<bib>
+  <mms_id>990023413370106761</mms_id>
+  <record_format>marc21</record_format>
+  <linked_record_id/>
+  <title>Aluminum statistical review for ...</title>
+  <author>Aluminum Association,</author>
+  <issn>2151-6847</issn>
+  <network_numbers>
+    <network_number>(OCoLC)915842621</network_number>
+    <network_number>(MCM)002341337MIT01</network_number>
+  </network_numbers>
+  <place_of_publication>Arlington, VA :</place_of_publication>
+  <date_of_publication>1966</date_of_publication>
+  <publisher_const>The Alumnium Association, Inc.</publisher_const>
+  <holdings link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990023413370106761/holdings"/>
+  <created_by>import</created_by>
+  <created_date>2021-06-30Z</created_date>
+  <suppress_from_publishing>false</suppress_from_publishing>
+  <suppress_from_external_search>false</suppress_from_external_search>
+  <sync_with_oclc>BIBS</sync_with_oclc>
+  <sync_with_libraries_australia>NONE</sync_with_libraries_australia>
+  <originating_system>ILS</originating_system>
+  <originating_system_id>002341337-MIT01</originating_system_id>
+  <cataloging_level desc="Default Level">00</cataloging_level>
+  <record schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+    <leader>     nas  2200373Ii 4500</leader>
+    <controlfield tag="001">990023413370106761</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(MCM)002341337MIT01</subfield>
+    </datafield>
+    <controlfield tag="005">20150806072509.0</controlfield>
+    <controlfield tag="006">m     o  d        </controlfield>
+    <controlfield tag="007">cr |||</controlfield>
+    <controlfield tag="008">150805c19669999vaugr   o     0    0eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="022">
+      <subfield code="l">2151-6847</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)915842621</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">MYG</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">MYG</subfield>
+      <subfield code="d">MYG</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="245">
+      <subfield code="a">Aluminum statistical review for ...</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">Arlington, VA :</subfield>
+      <subfield code="b">The Alumnium Association, Inc.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 online resource :</subfield>
+      <subfield code="b">color illustrations</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="310">
+      <subfield code="a">Biennial</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">computer</subfield>
+      <subfield code="b">c</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">online resource</subfield>
+      <subfield code="b">cr</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="347">
+      <subfield code="a">text file</subfield>
+      <subfield code="b">PDF</subfield>
+      <subfield code="2">rda</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="347">
+      <subfield code="a">data file</subfield>
+      <subfield code="b">XLS</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="362">
+      <subfield code="a">Print began in 1966.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Each issue consists of a PDF report, and several Excel files containing data tables.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="588">
+      <subfield code="a">Description based on: 2011; title from PDF cover.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="588">
+      <subfield code="a">Latest issue consulted: 2013.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Aluminum industry and trade</subfield>
+      <subfield code="v">Statistics</subfield>
+      <subfield code="v">Periodicals.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Statistics.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Periodicals.</subfield>
+      <subfield code="2">lcgft</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="8" tag="776">
+      <subfield code="i">Issued in print, 1966-2003:</subfield>
+      <subfield code="t">Aluminum statistical review</subfield>
+      <subfield code="x">0065-6666</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="8" tag="776">
+      <subfield code="i">Issued on CD-ROM, 2004-&lt;2006&gt;:</subfield>
+      <subfield code="t">Aluminum statistical review</subfield>
+      <subfield code="x">2151-6847</subfield>
+      <subfield code="w">(DLC)  2009234966</subfield>
+      <subfield code="w">(OCoLC)70009930</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Aluminum Association,</subfield>
+      <subfield code="e">issuing body.</subfield>
+    </datafield>
+    <datafield ind1="4" ind2="0" tag="856">
+      <subfield code="u">https://lib-ebooks.mit.edu/item/002341337</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">ba150805</subfield>
+      <subfield code="b">new</subfield>
+      <subfield code="c">~</subfield>
+      <subfield code="e">misc</subfield>
+      <subfield code="j">a</subfield>
+      <subfield code="k">s</subfield>
+      <subfield code="l">o</subfield>
+      <subfield code="m">I</subfield>
+      <subfield code="o">rda</subfield>
+      <subfield code="p">MYG</subfield>
+      <subfield code="q">n</subfield>
+      <subfield code="r">i</subfield>
+      <subfield code="s">1</subfield>
+      <subfield code="w">~</subfield>
+      <subfield code="x">0</subfield>
+      <subfield code="y">MAINT</subfield>
+      <subfield code="z">~</subfield>
+      <subfield code="i">ba</subfield>
+      <subfield code="d">150805</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">MARCIVEAUT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="049">
+      <subfield code="a">MYGG</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">ba150805</subfield>
+      <subfield code="b">new</subfield>
+      <subfield code="c">~</subfield>
+      <subfield code="e">misc</subfield>
+      <subfield code="j">a</subfield>
+      <subfield code="k">s</subfield>
+      <subfield code="l">o</subfield>
+      <subfield code="m">I</subfield>
+      <subfield code="o">rda</subfield>
+      <subfield code="p">MYG</subfield>
+      <subfield code="q">n</subfield>
+      <subfield code="r">i</subfield>
+      <subfield code="s">1</subfield>
+      <subfield code="w">~</subfield>
+      <subfield code="x">0</subfield>
+      <subfield code="y">MAINT</subfield>
+      <subfield code="z">~</subfield>
+      <subfield code="i">ba</subfield>
+      <subfield code="d">150805</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="949">
+      <subfield code="1">Internet Access</subfield>
+      <subfield code="a">n</subfield>
+      <subfield code="b">NET</subfield>
+      <subfield code="h">**See URL(s)</subfield>
+      <subfield code="o">8</subfield>
+      <subfield code="x">02</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="994">
+      <subfield code="a">02</subfield>
+      <subfield code="b">MYG</subfield>
+    </datafield>
+  </record>
+</bib>

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -6,21 +6,21 @@ def test_item_page_redirects_if_not_authenticated(app):
             in response.location
 
 
-def test_item_page_loads_if_authenticated(app, client, s3_conn, aleph):
+def test_item_page_loads_if_authenticated(app, client, s3_conn, alma):
     response = client.get('/item/sample')
     assert response.status_code == 200
 
 
-def test_item_page_displays_video_correctly(app, client, s3_conn, aleph):
+def test_item_page_displays_video_correctly(app, client, s3_conn, alma):
     response = client.get('/item/sample')
     assert b'<video width="100%" height="auto" controls>' in response.data
 
 
-def test_load_index_nonexistent_item(app, client, s3_conn, aleph):
+def test_load_index_nonexistent_item(app, client, s3_conn, alma):
     response = client.get('/item/fake_item')
     assert b'Item not found' in response.data
 
 
-def test_load_serial_item(app, client, s3_conn, aleph):
+def test_load_serial_item(app, client, s3_conn, alma):
     response = client.get('/item/serial')
     assert response.status_code == 200

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -9,7 +9,7 @@ def test_get_filenames(app, s3_conn):
 
 def test_get_metadata_from_record(app, record):
     r = get_metadata(record)
-    assert r['Title'] == 'Title Subtitle'
+    assert r['Title'] == 'Fundamentals of soil mechanics.'
 
 
 def test_get_volumes(app):


### PR DESCRIPTION
#### What does this PR do?
The application currently uses the Aleph API to retrieve metadata for ebook items. This updates the application to use the Alma API instead. Changes include:
* Updates configuration and query code to use Alma API key and URL
* Updates test fixtures and corresponding tests to use Alma sample records
* Updates documentation in README

#### Helpful background context
Note that the full application will not work until the file names for the ebook files (stored in S3) are updated to use the Alma MMSIDs instead of the Aleph bib record numbers. There is already a ticket for this. A single file has been updated for testing.

#### How can a reviewer manually see the effects of these changes?
Either locally (`pipenv run python runserver.py`) or in the PR build, go to <application_base_url>/item/990023413360106761 to see the item with files and metadata pulled from S3 and Alma, respectively. You will need the `ALMA_API_KEY` and `ALMA_API_URL` env variables set if you want to run it locally. They are set in the PR build env if you need them.

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/IMP-2010

#### Includes new or updated dependencies?
NO
