### PR TITLE
Update Talisman configurations to load external resources

### DIFF
--- a/ebooks/__init__.py
+++ b/ebooks/__init__.py
@@ -8,24 +8,41 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 def create_app():
     sentry_sdk.init(
-        dsn=os.getenv('SENTRY_DSN') or None,
-        integrations=[FlaskIntegration()]
-        )
+        dsn=os.getenv("SENTRY_DSN") or None, integrations=[FlaskIntegration()]
+    )
 
     app = Flask(__name__, instance_relative_config=True)
 
-    flask_env = os.getenv('FLASK_ENV', default='production')
-    if flask_env == 'development':
-        app.config.from_object('ebooks.config.DevelopmentConfig')
-    elif flask_env == 'testing':
-        app.config.from_object('ebooks.config.TestingConfig')
+    flask_env = os.getenv("FLASK_ENV", default="production")
+    if flask_env == "development":
+        app.config.from_object("ebooks.config.DevelopmentConfig")
+    elif flask_env == "testing":
+        app.config.from_object("ebooks.config.TestingConfig")
     else:
-        app.config.from_object('ebooks.config.Config')
+        app.config.from_object("ebooks.config.Config")
 
     from ebooks import auth, item
+
     app.register_blueprint(auth.bp)
     app.register_blueprint(item.bp)
 
-    Talisman(app)
+    csp = {
+        "default-src": [
+            "'self'",
+            "*.mit.edu",
+            "*.mitlibrary.net",
+            "*.bootstrapcdn.com",
+            "*.cloudflare.com",
+            "*.google-analytics.com",
+            "*.googleapis.com",
+            "*.gstatic.com",
+            "*.jquery.com",
+        ]
+    }
+    nonce_list = ["default-src", "script-src"]
+
+    Talisman(
+        app, content_security_policy=csp, content_security_policy_nonce_in=nonce_list
+    )
 
     return app

--- a/ebooks/templates/landing.html
+++ b/ebooks/templates/landing.html
@@ -182,7 +182,7 @@
     <script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
 
     <!-- ga -->
-    <script>
+    <script nonce="{{ csp_nonce() }}">
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/ebooks/templates/serial.html
+++ b/ebooks/templates/serial.html
@@ -165,7 +165,7 @@
     <script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
 
     <!-- ga -->
-    <script>
+    <script nonce="{{ csp_nonce() }}">
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
### Purpose and background context
While reviewing the MIT branding updates in production, a number of errors appeared in the console. The default Talisman content security policy configs are extremely strict and prevents loading any resources that are not in the same domain as the application. This resulted in the MIT images not rendering for the application (the images are loaded from our CDN). It also prevented running the script for Google Analytics.

The following resources guided this solution: 
* [Flask Talisman README | Content Security Policy](https://github.com/GoogleCloudPlatform/flask-talisman?tab=readme-ov-file#content-security-policy)
* [StackOverflow thread](https://stackoverflow.com/a/75806907/1196358)
* Thank you, @ghukill for your help! 🎉 

### How can a reviewer manually see the effects of these changes?

1. The screenshots attached to the description of the Jira ticket [PW-77](https://mitlibraries.atlassian.net/browse/PW-77) **still represent what the page looks like run locally (and theoretically, when deployed to production)**. There are three (3) files:
   * **ebooks_mobile_view.png**: Represents view of Ebooks app through a mobile device.
   * **ebooks_webpage.png**: Represents view of Ebooks app through a web browser.
   * **ebooks_webpage_annotated.png**: Represents view of Ebooks app through a web browser with annotations indicating the main MIT branding updates.

2. To see the errors that this PR addresses, visit https://lib-ebooks.mit.edu/item/9935069687606761:
   * See that the MIT logos / images fail to load.
   * If you navigate to the page -> right-click ->  select `Inspect` -> open `Console` tab: 
      * You'll see a handful of errors show up (a subset is shown below):
         ```
         Refused to load the stylesheet 'https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css' because it 
         violates the following Content Security Policy directive: "default-src 'self'". Note that 'style-src-elem' was not explicitly 
         set, so 'default-src' is used as a fallback.

         Refused to load the image 'https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico' because it violates the 
         following Content Security Policy directive: "default-src 'self'". Note that 'img-src' was not explicitly set, so 'default- 
         src' is used as a fallback.

         Refused to load the script 'https://libraries.mit.edu/wp-content/themes/libraries/js/modernizr.js?ver=2.8.1' because it 
         violates the following Content Security Policy directive: "default-src 'self'". Note that 'script-src-elem' was not explicitly 
         set, so 'default-src' is used as a fallback.

         Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self'". 
         Either the 'unsafe-inline' keyword, a hash ('sha256-TqW18/r0dsJXYVJEPKYVXh/dpVHYKKvT9c2RP4zVTCo='), or a 
         nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default- 
         src' is used as a fallback.
         ```
      * After applying the changes in this PR, this is what the app + browser console looks like:
         <img width="1676" alt="image" src="https://github.com/user-attachments/assets/a3f366db-a478-4f24-a086-f70e74f57a17">

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/PW-77

[PW-77]: https://mitlibraries.atlassian.net/browse/PW-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ