### PR TITLE
Update css and provide debug route

### DIFF
--- a/ebooks/item.py
+++ b/ebooks/item.py
@@ -63,3 +63,7 @@ def item(item="None"):
         return render_template(
             "landing.html", file_id=item, files=files, metadata=metadata, fields=fields
         )
+
+@bp.route("/debug")
+def debug(): 
+    return render_template("base.html")

--- a/ebooks/static/libraries-main.min.css
+++ b/ebooks/static/libraries-main.min.css
@@ -196,6 +196,7 @@ hr {
     font-size: 28px;
     margin-left: 20px;
     padding-left: 20px;
+	vertical-align: middle;
 }
 
 .wrap-outer-header.reasons {

--- a/ebooks/templates/base.html
+++ b/ebooks/templates/base.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en-US" class="no-js">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>MIT Libraries E-Book Delivery Service</title>
+
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
+        <link href={{ url_for('static', filename='libraries-main.min.css') }} rel="stylesheet" media="screen">
+
+        <link rel="shortcut icon", href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico"></link>
+
+        <!--added by Darcy to confirm w/ Google webmaster tools we own this site-->
+        <meta name="google-site-verification" content="82Cv3HFWvcefC_9XauvglcfB4h3o0uuiC3nKWWkL_eE" />
+
+        <script type='text/javascript' src='https://libraries.mit.edu/wp-content/themes/libraries/js/modernizr.js?ver=2.8.1'></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    </head>
+    <body>
+        <a id="skip" class="skip sr sr-focusable" href="#content-main">Skip to main content</a>
+        <div class="wrap-page">
+            <div class="wrap-outer-header layout-band">
+              <div class="wrap-header">
+                <header class="header-site header-slim" role="banner">
+                  <div class="wrap-header-core">
+                    <h1 class="name-site group nav-logo">
+                      <a href="https://libraries.mit.edu/" class="logo-mit-lib">
+                        <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo" height="35"/>
+                      </a>
+                      <span class="platform-name">Ebooks</span>
+                    </h1>
+                  </div>
+                  <div class="wrap-header-supp">
+                    <a class="link-logo-mit" href="https://www.mit.edu"><img src="https://cdn.libraries.mit.edu/files/branding/local/mit_logo_std_rgb_white.svg" alt="MIT" height="35"/></a>
+                  </div>
+                </header>
+              </div>
+            </div>
+
+            <div class="wrap-outer-content layout-band">
+                <div class="wrap-content layout-3q1q">
+                    <main id="content-main" class="content-main col3q" role="main">
+                      {% block content %}{% endblock content %}
+                    </main>
+                    <aside class="content-sup col1q-r" role="complementary">
+                      <div class="bit">
+                        <h3 class="title">On this page</h3>
+                        <ul>
+                          <li><a href="#content-main">Title and Author</a></li>
+                          <li><a href="#ebook-files">Digital Files</a></li>
+                          <li><a href="#ebook-supplementary">Supplementary information</a></li>
+                        </ul>
+                      </div>
+                      {% block related %}
+                        <div class="bit">
+                          <h3 class="title">Related</h3>
+                          <ul>
+                            <li><a href="https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=alma{{ file_id }}">View this item in the catalog</a></li>
+                          </ul>
+                        </div>
+                      {% endblock %}
+                    </aside>
+                </div>
+            </div>
+
+            <footer>
+                <div class="wrap-outer-footer layout-band">
+                  <div class="wrap-footer footer-slim">
+                    <div class="footer-main" aria-label="MIT Libraries footer">
+                      <div class="identity">
+                        <div class="wrap-logo-lib">
+                          <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
+                            <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo", width="150">
+                          </a>
+                        </div>
+                          <div class="wrap-middle">
+                            <div class="wrap-policies">
+                              <nav aria-label="MIT Libraries policy menu">
+                                <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+                                <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+                                <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
+                                <span class="item"><a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a></span>
+                              </nav>
+                            </div>
+                          </div>
+                      </div><!-- end .identity -->
+                    </div>
+                  </div>
+                </div>
+                <div class="wrap-outer-footer-institute layout-band">
+                  <div class="wrap-footer-institute">
+                    <div class="footer-info-institute">
+                      <a class="link-logo-mit" href="https://www.mit.edu">
+                        <img src="https://cdn.libraries.mit.edu/files/branding/local/mit_lockup_std-three-line_rgb_white.svg" alt="MIT" width="150"/>
+                      </a>
+                      <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+                      </div><!-- end .footer-info-institute -->
+                    </div>
+                  </div>
+                </div>
+            </footer>
+              
+        </div>
+      {% block script %}{% endblock script %}
+    </body>
+</html>
+
+
+  

--- a/ebooks/templates/landing.html
+++ b/ebooks/templates/landing.html
@@ -1,196 +1,84 @@
-<!DOCTYPE html>
-<!--[if lte IE 9]><html class="no-js lte-ie9" lang="en"><![endif]-->
-<!--[if !(IE 8) | !(IE 9) ]><!-->
-<html lang="en-US" class="no-js">
-<!--<![endif]-->
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MIT Libraries E-Book Delivery Service</title>
+{% extends 'base.html' %}
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
-    <link href={{ url_for('static', filename='libraries-main.min.css') }} rel="stylesheet" media="screen">
+{% block content %}
+<div class="wrap-ebook">
+  <h2 class="title title-page">MIT-hosted E-book</h2>
+  <dl class="ebook-details">
+    {% for f in fields %}
+      {% if f == 'Title' or f == 'Author' %}
+        {% if metadata[f] %}
+          <dt>{{ f }}</dt>
+          <dd class="ebook-{{ f|lower }}">{{ metadata[f] }}</dd>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
 
-    <link rel="shortcut icon", href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico"></link>
+    {% if metadata.Error %}
 
-    <!--added by Darcy to confirm w/ Google webmaster tools we own this site-->
-    <meta name="google-site-verification" content="82Cv3HFWvcefC_9XauvglcfB4h3o0uuiC3nKWWkL_eE" />
+    {% else %}
+      <dt id="ebook-files">Files</dt>
+      <dd class="ebook-files">
+        {% if files|length > 1 %}
+          <ul>
+            {% for file in files %}
+              {% if ".mp4" in file['name'] %}
+                <li><video width="100%" height="auto" controls>
+                  <source src="{{ file['url'] }}" type="video/mp4">
+                  <a href="{{ file['url'] }}">{{ file['name'] }}</a>
+                </video></li>
+              {% else %}
+                <li><a href="{{ file['url'] }}">{{ file['name'] }}</a></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        {% elif files|length == 1 %}
+          {% set file = files.0 %}
+          {% if ".mp4" in file['name'] %}
+            <video width="100%" height="auto" controls>
+              <source src="{{ file['url'] }}" type="video/mp4">
+              <a href="{{ file['url'] }}">{{ file['name'] }}</a>
+            </video>
+          {% else %}
+            <a href="{{ file['url'] }}">{{ file['name'] }}</a>
+          {% endif %}
+        {% else %}
+          No files available
+        {% endif %}
+      </dd>
+    {% endif %}
 
-    <script type='text/javascript' src='https://libraries.mit.edu/wp-content/themes/libraries/js/modernizr.js?ver=2.8.1'></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  </head>
+    <dt class="ebook-supplementary-title">Supplementary information</dt>
+    <dd id="ebook-supplementary" class="ebook-supplementary">
+      <dl class="ebook-supplementary-list">
+        {% for f in fields %}
+          {% if not f == 'Title' and not f == 'Author' %}
+            {% if metadata[f] %}
+              <dt>{{ f }}</dt>
+              <dd class="ebook-original">{{ metadata[f] }}</dd>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </dl>
+    </dd>
+  </dl>
+</div>
+{% endblock content %}
 
-  <body>
-    <a id="skip" class="skip sr sr-focusable" href="#content-main">Skip to main content</a>
+{% block script %}
+<!-- jquery -->
+<script src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
 
-    <div class="wrap-page">
-      <div class="wrap-outer-header layout-band">
-        <div class="wrap-header">
-          <header class="header-site header-slim" role="banner">
-            <div class="wrap-header-core">
-              <h1 class="name-site group nav-logo">
-                <a href="https://libraries.mit.edu/" class="logo-mit-lib">
-                  <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo" height="35"/>
-                </a>
-                <span class="platform-name">Ebooks</span>
-              </h1>
-            </div>
-            <div class="wrap-header-supp">
-              <a class="link-logo-mit" href="https://www.mit.edu"><img src="https://cdn.libraries.mit.edu/files/branding/local/mit_logo_std_rgb_white.svg" alt="MIT" height="35"/></a>
-            </div>
-          </header>
-        </div>
-      </div>
+<!-- ga -->
+<script nonce="{{ csp_nonce() }}">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-      <div class="wrap-outer-content layout-band">
-        <div class="wrap-content layout-3q1q">
-          <main id="content-main" class="content-main col3q" role="main">
+ga('create', 'UA-1760176-1', 'auto');
+ga('send', 'pageview');
+</script>
+{% endblock script %}
 
-            <div class="wrap-ebook">
 
-              <h2 class="title title-page">MIT-hosted E-book</h2>
-
-              <dl class="ebook-details">
-                {% for f in fields %}
-                  {% if f == 'Title' or f == 'Author' %}
-                    {% if metadata[f] %}
-                      <dt>{{ f }}</dt>
-                      <dd class="ebook-{{ f|lower }}">{{ metadata[f] }}</dd>
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-
-                {% if metadata.Error %}
-
-                {% else %}
-                  <dt id="ebook-files">Files</dt>
-                  <dd class="ebook-files">
-                    {% if files|length > 1 %}
-                      <ul>
-                        {% for file in files %}
-                          {% if ".mp4" in file['name'] %}
-                            <li><video width="100%" height="auto" controls>
-                              <source src="{{ file['url'] }}" type="video/mp4">
-                              <a href="{{ file['url'] }}">{{ file['name'] }}</a>
-                            </video></li>
-                          {% else %}
-                            <li><a href="{{ file['url'] }}">{{ file['name'] }}</a></li>
-                          {% endif %}
-                        {% endfor %}
-                      </ul>
-                    {% elif files|length == 1 %}
-                      {% set file = files.0 %}
-                      {% if ".mp4" in file['name'] %}
-                        <video width="100%" height="auto" controls>
-                          <source src="{{ file['url'] }}" type="video/mp4">
-                          <a href="{{ file['url'] }}">{{ file['name'] }}</a>
-                        </video>
-                      {% else %}
-                        <a href="{{ file['url'] }}">{{ file['name'] }}</a>
-                      {% endif %}
-                    {% else %}
-                      No files available
-                    {% endif %}
-                  </dd>
-                {% endif %}
-
-                <dt class="ebook-supplementary-title">Supplementary information</dt>
-                <dd id="ebook-supplementary" class="ebook-supplementary">
-                  <dl class="ebook-supplementary-list">
-                    {% for f in fields %}
-                      {% if not f == 'Title' and not f == 'Author' %}
-                        {% if metadata[f] %}
-                          <dt>{{ f }}</dt>
-                          <dd class="ebook-original">{{ metadata[f] }}</dd>
-                        {% endif %}
-                      {% endif %}
-                    {% endfor %}
-                  </dl>
-                </dd>
-
-            </div>
-          </main>
-          <!-- close content-main -->
-
-          <aside class="content-sup col1q-r" role="complementary">
-
-            <div class="bit">
-              <h3 class="title">On this page</h3>
-              <ul>
-                <li><a href="#content-main">Title and Author</a></li>
-                <li><a href="#ebook-files">Digital Files</a></li>
-                <li><a href="#ebook-supplementary">Supplementary information</a></li>
-              </ul>
-            </div>
-
-            {% block related %}
-              <div class="bit">
-                <h3 class="title">Related</h3>
-                <ul>
-                  <li><a href="https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=alma{{ file_id }}">View this item in the catalog</a></li>
-                </ul>
-              </div>
-            {% endblock %}
-
-          </aside>
-        </div>
-      </div>
-
-      <footer>
-        <div class="wrap-outer-footer layout-band">
-          <div class="wrap-footer footer-slim">
-            <div class="footer-main" aria-label="MIT Libraries footer">
-              <div class="identity">
-                <div class="wrap-logo-lib">
-                  <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
-                    <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo">
-                  </a>
-                </div>
-                  <div class="wrap-middle">
-                    <div class="wrap-policies">
-                      <nav aria-label="MIT Libraries policy menu">
-                        <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a></span>
-                      </nav>
-                    </div>
-                  </div>
-              </div><!-- end .identity -->
-            </div>
-          </div>
-        </div>
-        <div class="wrap-outer-footer-institute layout-band">
-          <div class="wrap-footer-institute">
-            <div class="footer-info-institute">
-              <a class="link-logo-mit" href="https://www.mit.edu">
-                <img src="https://cdn.libraries.mit.edu/files/branding/local/mit_lockup_std-three-line_rgb_white.svg" alt="MIT" width="150"/>
-              </a>
-              <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-              </div><!-- end .footer-info-institute -->
-            </div>
-          </div>
-        </div>
-      </footer>
-
-    </div><!-- close wrap-page -->
-
-    <!-- jquery -->
-    <script src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
-
-    <!-- ga -->
-    <script nonce="{{ csp_nonce() }}">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-1760176-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-  </body>
-</html>

--- a/ebooks/templates/serial.html
+++ b/ebooks/templates/serial.html
@@ -1,179 +1,66 @@
-<!DOCTYPE html>
-<!--[if lte IE 9]><html class="no-js lte-ie9" lang="en"><![endif]-->
-<!--[if !(IE 8) | !(IE 9) ]><!-->
-<html lang="en-US" class="no-js">
-<!--<![endif]-->
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MIT Libraries E-Book Delivery Service</title>
+{% extends 'base.html' %}
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
-    <link href={{ url_for('static', filename='libraries-main.min.css') }} rel="stylesheet" media="screen">
+{% block content %}
+<div class="wrap-ebook">
+  <h2 class="title title-page">MIT-hosted E-book</h2>
+  <dl class="ebook-details">
+    {% for f in fields %}
+      {% if f == 'Title' or f == 'Author' %}
+        {% if metadata[f] %}
+          <dt>{{ f }}</dt>
+          <dd class="ebook-{{ f|lower }}">{{ metadata[f] }}</dd>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
 
-    <link rel="shortcut icon", href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico"></link>
+    {% if metadata.Error %}
 
-    <!--added by Darcy to confirm w/ Google webmaster tools we own this site-->
-    <meta name="google-site-verification" content="82Cv3HFWvcefC_9XauvglcfB4h3o0uuiC3nKWWkL_eE" />
+    {% else %}
+      <dt id="ebook-files">Files</dt>
+      <dd class="ebook-files">
+        {% for volume in volumes %}
+          <h3 class="ebooks-files-title">Volume {{ volume }}</h3>
+          <ul>
+            {% for file in volumes[volume] %}
+              <li><a href="{{ file['url'] }}">{{ file['name'] }}</a></li>
+            {% endfor %}
+          </ul>
+        {% endfor %}
+      </dd>
+    {% endif %}
 
-    <script type='text/javascript' src='https://libraries.mit.edu/wp-content/themes/libraries/js/modernizr.js?ver=2.8.1'></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  </head>
+    <dt class="ebook-supplementary-title">Supplementary information</dt>
+    <dd id="ebook-supplementary" class="ebook-supplementary">
+      <dl class="ebook-supplementary-list">
+        {% for f in fields %}
+          {% if not f == 'Title' and not f == 'Author' %}
+            {% if metadata[f] %}
+              <dt>{{ f }}</dt>
+              <dd class="ebook-original">{{ metadata[f] }}</dd>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </dl>
+    </dd>
+  </dl>
+</div>
+{% endblock content %}
 
-  <body>
-    <a id="skip" class="skip sr sr-focusable" href="#content-main">Skip to main content</a>
+{% block script %}
+<!-- jquery -->
+<script src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
 
-    <div class="wrap-page">
-      <div class="wrap-outer-header layout-band">
-        <div class="wrap-header">
-          <header class="header-site header-slim" role="banner">
-            <div class="wrap-header-core">
-              <h1 class="name-site group nav-logo">
-                <a href="https://libraries.mit.edu/" class="logo-mit-lib">
-                  <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo" height="35"/>
-                </a>
-                <span class="platform-name">Ebooks</span>
-              </h1>
-            </div>
-            <div class="wrap-header-supp">
-              <a class="link-logo-mit" href="https://www.mit.edu"><img src="https://cdn.libraries.mit.edu/files/branding/local/mit_logo_std_rgb_white.svg" alt="MIT" height="35"/></a>
-            </div>
-          </header>
-        </div>
-      </div>
+<!-- ga -->
+<script nonce="{{ csp_nonce() }}">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-      <div class="wrap-outer-content layout-band">
-        <div class="wrap-content layout-3q1q">
-          <main id="content-main" class="content-main col3q" role="main">
+ga('create', 'UA-1760176-1', 'auto');
+ga('send', 'pageview');
 
-            <div class="wrap-ebook">
+</script>
+{% endblock script %}
 
-              <h2 class="title title-page">MIT-hosted E-book</h2>
-
-              <dl class="ebook-details">
-                {% for f in fields %}
-                  {% if f == 'Title' or f == 'Author' %}
-                    {% if metadata[f] %}
-                      <dt>{{ f }}</dt>
-                      <dd class="ebook-{{ f|lower }}">{{ metadata[f] }}</dd>
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-
-                {% if metadata.Error %}
-
-                {% else %}
-                  <dt id="ebook-files">Files</dt>
-                  <dd class="ebook-files">
-                    {% for volume in volumes %}
-                      <h3 class="ebooks-files-title">Volume {{ volume }}</h3>
-                      <ul>
-                        {% for file in volumes[volume] %}
-                          <li><a href="{{ file['url'] }}">{{ file['name'] }}</a></li>
-                        {% endfor %}
-                      </ul>
-                    {% endfor %}
-                  </dd>
-                {% endif %}
-
-                <dt class="ebook-supplementary-title">Supplementary information</dt>
-                <dd id="ebook-supplementary" class="ebook-supplementary">
-                  <dl class="ebook-supplementary-list">
-                    {% for f in fields %}
-                      {% if not f == 'Title' and not f == 'Author' %}
-                        {% if metadata[f] %}
-                          <dt>{{ f }}</dt>
-                          <dd class="ebook-original">{{ metadata[f] }}</dd>
-                        {% endif %}
-                      {% endif %}
-                    {% endfor %}
-                  </dl>
-                </dd>
-
-            </div>
-          </main>
-          <!-- close content-main -->
-
-          <aside class="content-sup col1q-r" role="complementary">
-
-            <div class="bit">
-              <h3 class="title">On this page</h3>
-              <ul>
-                <li><a href="#content-main">Title and Author</a></li>
-                <li><a href="#ebook-files">Digital Files</a></li>
-                <li><a href="#ebook-supplementary">Supplementary information</a></li>
-              </ul>
-            </div>
-
-            {% block related %}
-              <div class="bit">
-                <h3 class="title">Related</h3>
-                <ul>
-                  <li><a href="https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=alma{{ file_id }}">View this item in the catalog</a></li>
-                </ul>
-              </div>
-            {% endblock %}
-
-          </aside>
-        </div>
-      </div>
-
-      <footer>
-        <div class="wrap-outer-footer layout-band">
-          <div class="wrap-footer footer-slim">
-            <div class="footer-main" aria-label="MIT Libraries footer">
-              <div class="identity">
-                <div class="wrap-logo-lib">
-                  <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
-                    <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" alt="MIT Libraries logo", width="150">
-                  </a>
-                </div>
-                  <div class="wrap-middle">
-                    <div class="wrap-policies">
-                      <nav aria-label="MIT Libraries policy menu">
-                        <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
-                        <span class="item"><a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a></span>
-                      </nav>
-                    </div>
-                  </div>
-              </div><!-- end .identity -->
-            </div>
-          </div>
-        </div>
-        <div class="wrap-outer-footer-institute layout-band">
-          <div class="wrap-footer-institute">
-            <div class="footer-info-institute">
-              <a class="link-logo-mit" href="https://www.mit.edu">
-                <img src="https://cdn.libraries.mit.edu/files/branding/local/mit_lockup_std-three-line_rgb_white.svg" alt="MIT" width="150"/>
-              </a>
-              <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-              </div><!-- end .footer-info-institute -->
-            </div>
-          </div>
-        </div>
-      </footer>
-
-    </div>
-    <!-- close wrap-page -->
-
-    <!-- jquery -->
-    <script src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/jquery-migrate-1.4.0.min.js" integrity="sha256-nxdiQ4FdTm28eUNNQIJz5JodTMCF5/l32g5LwfUwZUo=" crossorigin="anonymous"></script>
-
-    <!-- ga -->
-    <script nonce="{{ csp_nonce() }}">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-1760176-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-  </body>
-</html>


### PR DESCRIPTION
### Purpose and background context

This PR fixes the vertical alignment of the platform name in the header (see [@darcyduke 's comment on PW-77](https://mitlibraries.atlassian.net/browse/PW-77?focusedCommentId=135261)) and add "debug" route for viewing frontend changes without requiring authentication. 

While the initial goal of this issue was to address the former, It seemed like a good time to provide a "debug" route to ease review--an idea floated by @JPrevost --(at least until we get around to updating authentication for the app). I also took it as an opportunity to add a `base.html` template to cut down on some of the duplicated code in the `landing` and `serial` HTML pages.

### How can a reviewer manually see the effects of these changes?

Please review the app in `staging`: https://mit-ebooks-staging.herokuapp.com/item/debug. 

### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/PW-77

